### PR TITLE
Remove `12.x-dev` from `laravel_version_compare()`

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -94,7 +94,6 @@ function laravel_version_compare(string $version, ?string $operator = null): int
         Application::VERSION,
         fn (string $version) => match ($version) {
             '13.x-dev' => '13.0.0',
-            '12.x-dev' => '12.0.0',
             default => $version,
         }
     );


### PR DESCRIPTION
The version no longer exists since the release of Laravel Framework 12.0.0